### PR TITLE
fix: change owner switchLanguage trigger

### DIFF
--- a/src/components/layout/Layout_DesktopMenu.tsx
+++ b/src/components/layout/Layout_DesktopMenu.tsx
@@ -86,12 +86,12 @@ const LayoutMenu: React.FC = () => {
           <Switch onClick={toggleTheme} checked={colorMode == "dark"} />
         </MenuThemeContainer>
 
-        <MenuThemeContainer onClick={switchLanguage}>
+        <MenuThemeContainer >
           <Row centeredY>
             <LanguageIcon size={16} />
             <MenuText>{t(i18n.resolvedLanguage)}</MenuText>
           </Row>
-          <LanguageButton>
+          <LanguageButton onClick={switchLanguage}>
             {t(i18n.resolvedLanguage === "en" ? "ko" : "en")}
           </LanguageButton>
         </MenuThemeContainer>

--- a/src/components/layout/Layout_MobileMenuModal.tsx
+++ b/src/components/layout/Layout_MobileMenuModal.tsx
@@ -54,12 +54,12 @@ const LayoutMobileMenuModalTrigger: React.FC<Props> = ({ children }) => {
             <Switch onClick={toggleTheme} checked={colorMode === "dark"} />
           </MenuThemeContainer>
 
-          <MenuThemeContainer onClick={switchLanguage}>
+          <MenuThemeContainer >
             <Row centeredY>
               <LanguageIcon size={16} />
               <MenuText>{t(i18n.resolvedLanguage)}</MenuText>
             </Row>
-            <LanguageButton>
+            <LanguageButton onClick={switchLanguage}>
               {t(i18n.resolvedLanguage === "en" ? "ko" : "en")}
             </LanguageButton>
           </MenuThemeContainer>


### PR DESCRIPTION
### 관련이슈 #6 

해당 이슈에서 언급된 이슈를 확인하고, 소스를 확인했습니다. 


https://github.com/chinchiilla/corona-live-v4/blob/ffb3000b8848784fcd5d4e653814c6d399e8c08a/src/components/layout/Layout_DesktopMenu.tsx#L89-L98

https://github.com/chinchiilla/corona-live-v4/blob/ffb3000b8848784fcd5d4e653814c6d399e8c08a/src/components/layout/Layout_MobileMenuModal.tsx#L57-L65

위 부분에서 `onClick` 이벤트가 버튼이 아닌 컨테이너에 걸려있더라구요! 
컨테이너에 이벤트를 거시려고 의도하신 것이 아니시면,  
`<LanguageButton>` 버튼의 `onClick`으로 `switchLanguage`을 넣어주면 좋을 것 같습니다 😄 